### PR TITLE
Fix Nunchaku LoRA loading in ModelPatcher.py (ComfyUI v0.6.0)

### DIFF
--- a/nodes/lora/flux.py
+++ b/nodes/lora/flux.py
@@ -3,7 +3,7 @@ This module provides the :class:`NunchakuFluxLoraLoader` node
 for applying LoRA weights to Nunchaku FLUX models within ComfyUI.
 """
 
-import copy
+import copy  # Keep if needed elsewhere, but remove for model
 import logging
 import os
 
@@ -114,7 +114,8 @@ class NunchakuFluxLoraLoader:
 
         transformer = model_wrapper.model
         model_wrapper.model = None
-        ret_model = copy.deepcopy(model)  # copy everything except the model
+#       ret_model = copy.deepcopy(model)  # copy everything except the model
+        ret_model = model.clone()  # Use the patcher's safe clone method
         ret_model_wrapper = ret_model.model.diffusion_model
         assert isinstance(ret_model_wrapper, ComfyFluxWrapper)
 

--- a/nodes/lora/flux.py
+++ b/nodes/lora/flux.py
@@ -114,7 +114,6 @@ class NunchakuFluxLoraLoader:
 
         transformer = model_wrapper.model
         model_wrapper.model = None
-#       ret_model = copy.deepcopy(model)  # copy everything except the model
         ret_model = model.clone()  # Use the patcher's safe clone method
         ret_model_wrapper = ret_model.model.diffusion_model
         assert isinstance(ret_model_wrapper, ComfyFluxWrapper)


### PR DESCRIPTION
## Motivation

After updating ComfyUI to version 0.6.0 -- Nunchaku Flux LoRA Loader getting this error:
```
!!! Exception during processing !!! 'NoneType' object is not callable
Traceback (most recent call last):
  File "c:\ComfyUI\execution.py", line 516, in execute
    output_data, output_ui, has_subgraph, has_pending_tasks = await get_output_data(prompt_id, unique_id, obj, input_data_all, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb, v3_data=v3_data)
                                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\ComfyUI\execution.py", line 330, in get_output_data
    return_values = await _async_map_node_over_list(prompt_id, unique_id, obj, input_data_all, obj.FUNCTION, allow_interrupt=True, execution_block_cb=execution_block_cb, pre_execute_cb=pre_execute_cb, v3_data=v3_data)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "c:\ComfyUI\execution.py", line 304, in _async_map_node_over_list
    await process_inputs(input_dict, i)
  File "c:\ComfyUI\execution.py", line 292, in process_inputs
    result = f(**inputs)
             ^^^^^^^^^^^
  File "C:\ComfyUI\custom_nodes\ComfyUI-nunchaku\nodes\lora\flux.py", line 117, in load_lora
    ret_model = copy.deepcopy(model)  # copy everything except the model
                ^^^^^^^^^^^^^^^^^^^^
  File "C:\ProgramData\miniconda3\Lib\copy.py", line 162, in deepcopy
    y = _reconstruct(x, memo, *rv)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\ProgramData\miniconda3\Lib\copy.py", line 259, in _reconstruct
    state = deepcopy(state, memo)
            ^^^^^^^^^^^^^^^^^^^^^
  File "C:\ProgramData\miniconda3\Lib\copy.py", line 136, in deepcopy
    y = copier(x, memo)
        ^^^^^^^^^^^^^^^
  File "C:\ProgramData\miniconda3\Lib\copy.py", line 221, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
                             ^^^^^^^^^^^^^^^^^^^^^
  File "C:\ProgramData\miniconda3\Lib\copy.py", line 162, in deepcopy
    y = _reconstruct(x, memo, *rv)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\ProgramData\miniconda3\Lib\copy.py", line 259, in _reconstruct
    state = deepcopy(state, memo)
            ^^^^^^^^^^^^^^^^^^^^^
  File "C:\ProgramData\miniconda3\Lib\copy.py", line 136, in deepcopy
    y = copier(x, memo)
        ^^^^^^^^^^^^^^^
  File "C:\ProgramData\miniconda3\Lib\copy.py", line 221, in _deepcopy_dict
    y[deepcopy(key, memo)] = deepcopy(value, memo)
                             ^^^^^^^^^^^^^^^^^^^^^
  File "C:\ProgramData\miniconda3\Lib\copy.py", line 162, in deepcopy
    y = _reconstruct(x, memo, *rv)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\ProgramData\miniconda3\Lib\copy.py", line 261, in _reconstruct
    y.__setstate__(state)
TypeError: 'NoneType' object is not callable

Prompt executed in 48.54 seconds
Exception ignored in: <function ModelPatcher.__del__ at 0x000002386C4B67A0>
Traceback (most recent call last):
  File "c:\ComfyUI\comfy\model_patcher.py", line 1357, in __del__
    self.unpin_all_weights()
  File "c:\ComfyUI\comfy\model_patcher.py", line 654, in unpin_all_weights
    for key in list(self.pinned):
                    ^^^^^^^^^^^
AttributeError: 'ModelPatcher' object has no attribute 'pinned'
```

## Modifications

This fix TypeError during LoRA loading as deepcopy fails on ModelPatcher objects.
**Pull reqiest for fix C:\ComfyUI\comfy\model_patcher.py -- [https://github.com/comfyanonymous/ComfyUI/pull/11507](https://github.com/comfyanonymous/ComfyUI/pull/11507).
