### PR TITLE
fix(qwenimage): support index_timestep_zero for Qwen-Image-Edit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,11 +15,12 @@ repos:
       - id: check-ast
       - id: check-added-large-files
       - id: check-merge-conflict
-      #      - id: check-shebang-scripts-are-executable
       - id: detect-private-key
         #      - id: debug-statements
-        #      - id: no-commit-to-branch
   - repo: https://github.com/PyCQA/isort
+    #      - id: no-commit-to-branch
+
+    #      - id: check-shebang-scripts-are-executable
     rev: 6.1.0
     hooks:
       - id: isort

--- a/models/qwenimage.py
+++ b/models/qwenimage.py
@@ -401,7 +401,7 @@ class NunchakuQwenImageTransformerBlock(nn.Module):
             **kwargs,
         )
 
-    def _modulate(self, x: torch.Tensor, mod_params: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    def _modulate(self, x: torch.Tensor, mod_params: torch.Tensor, timestep_zero_index=None) -> Tuple[torch.Tensor, torch.Tensor]:
         """
         Apply modulation to input tensor.
 
@@ -411,15 +411,35 @@ class NunchakuQwenImageTransformerBlock(nn.Module):
             Input tensor of shape (batch, seq_len, dim).
         mod_params : torch.Tensor
             Modulation parameters of shape (batch, 3*dim).
+        timestep_zero_index : int, optional
+            The sequence index used to split the input tensor for dual-timestep modulation 
+            (e.g., normal vs. zero timestep). If provided, different modulation parameters 
+            are applied to the segments before and after this index.
 
         Returns
         -------
         modulated_x : torch.Tensor
             Modulated tensor.
-        gate : torch.Tensor
-            Gate tensor for residual connection.
+        gate : torch.Tensor or tuple of torch.Tensor
+            Gate tensor for residual connection. Returns a tuple of gates if 
+            timestep_zero_index is provided.
         """
         shift, scale, gate = mod_params.chunk(3, dim=-1)
+        
+        if timestep_zero_index is not None:
+            # Handle index_timestep_zero logic
+            actual_batch = shift.size(0) // 2
+            # Split into normal part and t=0 part
+            shift, shift_0 = shift[:actual_batch], shift[actual_batch:]
+            scale, scale_0 = scale[:actual_batch], scale[actual_batch:]
+            gate, gate_0 = gate[:actual_batch], gate[actual_batch:]
+            
+            # Apply separately to different parts of the sequence
+            reg = x[:, :timestep_zero_index] * (1 + scale.unsqueeze(1)) + shift.unsqueeze(1)
+            zero = x[:, timestep_zero_index:] * (1 + scale_0.unsqueeze(1)) + shift_0.unsqueeze(1)
+            
+            return torch.cat((reg, zero), dim=1), (gate.unsqueeze(1), gate_0.unsqueeze(1))
+
         if self.scale_shift != 0:
             scale.add_(self.scale_shift)
         return x * scale.unsqueeze(1) + shift.unsqueeze(1), gate.unsqueeze(1)
@@ -448,6 +468,10 @@ class NunchakuQwenImageTransformerBlock(nn.Module):
             Timestep or conditioning embedding.
         image_rotary_emb : tuple of torch.Tensor, optional
             Rotary positional embeddings.
+        timestep_zero_index : int, optional
+            The sequence index used to split the image stream for dual-timestep modulation.
+            If provided, handles the special logic where a portion of the sequence 
+            (e.g., reference latents) is conditioned with a zero timestep.
 
         Returns
         -------
@@ -458,7 +482,12 @@ class NunchakuQwenImageTransformerBlock(nn.Module):
         """
         # Get modulation parameters for both streams
         img_mod_params = self.img_mod(temb)  # [B, 6*dim]
-        txt_mod_params = self.txt_mod(temb)  # [B, 6*dim]
+        
+        # Process temb for the text side (text does not require zero index splitting)
+        txt_temb = temb
+        if timestep_zero_index is not None:
+            txt_temb = temb.chunk(2, dim=0)[0]
+        txt_mod_params = self.txt_mod(txt_temb)  # [B, 6*dim]
 
         # Nunchaku's mod_params is [B, 6*dim] instead of [B, dim*6]
         img_mod_params = (
@@ -473,7 +502,7 @@ class NunchakuQwenImageTransformerBlock(nn.Module):
 
         # Process image stream - norm1 + modulation
         img_normed = self.img_norm1(hidden_states)
-        img_modulated, img_gate1 = self._modulate(img_normed, img_mod1)
+        img_modulated, img_gate1 = self._modulate(img_normed, img_mod1, timestep_zero_index)
 
         # Process text stream - norm1 + modulation
         txt_normed = self.txt_norm1(encoder_hidden_states)
@@ -489,17 +518,33 @@ class NunchakuQwenImageTransformerBlock(nn.Module):
 
         # QwenAttnProcessor2_0 returns (img_output, txt_output) when encoder_hidden_states is provided
         img_attn_output, txt_attn_output = attn_output
-
-        # Apply attention gates and add residual (like in Megatron)
-        hidden_states = hidden_states + img_gate1 * img_attn_output
+        
+        # Residual connection and gate processing
+        if timestep_zero_index is not None:
+            # Handle concatenation for split gates
+            hidden_states = hidden_states + torch.cat([
+                img_attn_output[:, :timestep_zero_index] * img_gate1[0],
+                img_attn_output[:, timestep_zero_index:] * img_gate1[1]
+            ], dim=1)
+        else:
+            # Apply attention gates and add residual (like in Megatron)
+            hidden_states = hidden_states + img_gate1 * img_attn_output
+            
         encoder_hidden_states = encoder_hidden_states + txt_gate1 * txt_attn_output
 
         # Process image stream - norm2 + MLP
         img_normed2 = self.img_norm2(hidden_states)
-        img_modulated2, img_gate2 = self._modulate(img_normed2, img_mod2)
+        img_modulated2, img_gate2 = self._modulate(img_normed2, img_mod2, timestep_zero_index)
         img_mlp_output = self.img_mlp(img_modulated2)
-        hidden_states = hidden_states + img_gate2 * img_mlp_output
-
+        
+        if timestep_zero_index is not None:
+            hidden_states = hidden_states + torch.cat([
+                img_mlp_output[:, :timestep_zero_index] * img_gate2[0],
+                img_mlp_output[:, timestep_zero_index:] * img_gate2[1]
+            ], dim=1)
+        else:
+            hidden_states = hidden_states + img_gate2 * img_mlp_output
+            
         # Process text stream - norm2 + MLP
         txt_normed2 = self.txt_norm2(encoder_hidden_states)
         txt_modulated2, txt_gate2 = self._modulate(txt_normed2, txt_mod2)
@@ -806,6 +851,10 @@ class NunchakuQwenImageTransformer2DModel(NunchakuModelMixin, QwenImageTransform
 
             if self.offload:
                 self.offload_manager.step(compute_stream)
+                
+        # Process final normalization
+        if timestep_zero_index is not None:
+            temb = temb.chunk(2, dim=0)[0]
 
         hidden_states = self.norm_out(hidden_states, temb)
         hidden_states = self.proj_out(hidden_states)

--- a/test_data/models.yaml
+++ b/test_data/models.yaml
@@ -36,13 +36,15 @@ models:
     filename: "z_image_turbo_childrens_drawings.safetensors"
     sub_folder: "loras"
     new_filename: null
-  # nunchaku text encoders
   - repo_id: "nunchaku-tech/nunchaku-t5"
+    # nunchaku text encoders
+
     filename: "awq-int4-flux.1-t5xxl.safetensors"
     sub_folder: "text_encoders"
     new_filename: null
-  # nunchaku diffusion models
   - repo_id: "nunchaku-tech/nunchaku-flux.1-dev"
+    # nunchaku diffusion models
+
     filename: "svdq-{precision}_r32-flux.1-dev.safetensors"
     sub_folder: "diffusion_models"
     new_filename: null
@@ -102,8 +104,9 @@ models:
     filename: "svdq-{precision}_r128-z-image-turbo.safetensors"
     sub_folder: "diffusion_models"
     new_filename: null
-  # pulid related
   - repo_id: "guozinan/PuLID"
+    # pulid related
+
     filename: "pulid_flux_v0.9.1.safetensors"
     sub_folder: "pulid"
     new_filename: null
@@ -111,8 +114,9 @@ models:
     filename: "EVA02_CLIP_L_336_psz14_s6B.pt"
     sub_folder: "clip"
     new_filename: null
-  # other
   - repo_id: "Shakker-Labs/FLUX.1-dev-ControlNet-Union-Pro-2.0"
+    # other
+
     filename: "diffusion_pytorch_model.safetensors"
     sub_folder: "controlnet"
     new_filename: "controlnet-union-pro-2.0.safetensors"


### PR DESCRIPTION
## Motivation

When using editing-based models (specifically Qwen-Image-Edit-2511), the index_timestep_zero reference method is required for positive conditioning to maintain high output quality. Without this specialized handling, the model fails to correctly anchor the reference image at the zero-noise state, leading to significantly degraded output quality or artifacts.

Currently, the qwenimage.py implementation in ComfyUI-nunchaku lacks the internal logic to handle this method. When index_timestep_zero is enabled, ComfyUI doubles the batch size of the timestep embeddings (temb), but the Nunchaku transformer blocks do not account for this batch doubling. This results in:

1. Incorrect Broadcasting: The hidden states (batch 1) are incorrectly broadcasted across the doubled temb (batch 2).
2. Runtime Crash: The process eventually fails with RuntimeError: shape '[1, ...]' is invalid for input of size [403200] because the final output size is twice what the model's output reshaping expects.

This 'Shape is invalid' issue has also been reported by others in the Hugging Face community. You can refer to this discussion for more context: [Shape '[1, 52, 78, 16, 2, 2]' is invalid for input of size 519168 when using index_timestep_zero to fix image quality](https://huggingface.co/QuantFunc/Nunchaku-Qwen-Image-EDIT-2511/discussions/2)


## Modifications
fix(qwenimage): support index_timestep_zero for Qwen-Image-Edit

- Implement timestep_zero_index handling in NunchakuQwenImageTransformerBlock.
- Update _modulate to correctly split modulation parameters for doubled batches.
- Ensure residual connections use split gates when Kontext reference method is used.
- Fixes RuntimeError: 'shape is invalid for input of size...' during inference.

## Testing
This modification has been verified in ComfyUI with the FluxKontextMultiReferenceLatentMethod node set to index_timestep_zero. The image generation task now completes successfully as expected.


## Checklist

- [X] Code is formatted using Pre-Commit hooks (run `pre-commit run --all-files`).
- [ ] Relevant unit tests are added in the [`tests/workflows`](../tests/workflows) directory following the guidance in the [Contribution Guide](https://nunchaku.tech/docs/comfyui-nunchaku/developer/contribution_guide.html).
- [ ] Reference images are uploaded to PR comments and URLs are added to `test_cases.json`.
- [ ] Additional test data (if needed) is registered in [`test_data/inputs.yaml`](../test_data/inputs.yaml).
- [ ] Additional models (if needed) are registered in [`scripts/download_models.py`](../scripts/download_models.py) and [`test_data/models.yaml`](../test_data/models.yaml).
- [ ] Additional custom nodes (if needed) are added to [`.github/workflows/pr-test.yaml`](../.github/workflows/pr-test.yaml).
- [ ] **For reviewers:** If you're only helping merge the main branch and haven't contributed code to this PR, please remove yourself as a co-author when merging.
- [ ] Please feel free to join our [Discord](https://discord.gg/Wk6PnwX9Sm) or [WeChat](https://huggingface.co/datasets/nunchaku-tech/cdn/blob/main/nunchaku/assets/wechat.jpg) to discuss your PR.
