### PR TITLE
fix: weight dereferenced before torch_dtype/device kwargs are honoured (ComfyUI 0.33 lazy Linear)

### DIFF
--- a/models/zimage.py
+++ b/models/zimage.py
@@ -59,13 +59,31 @@ def fuse_to_svdquant_linear(comfy_linear1: nn.Linear, comfy_linear2: nn.Linear, 
     """
     assert comfy_linear1.in_features == comfy_linear2.in_features
     assert comfy_linear1.bias is None and comfy_linear2.bias is None
-    torch_dtype = kwargs.pop("torch_dtype", comfy_linear1.weight.dtype)
+    # `dict.pop(key, default)` evaluates its default eagerly, so `comfy_linear1.weight.dtype`
+    # is read even when the caller passes `torch_dtype`. ComfyUI 0.33 ships a Windows-only lazy
+    # `Linear` (comfy/ops.py) whose `weight` stays None until `_load_from_state_dict` runs, and
+    # patching happens before that -- so this line raises `AttributeError: 'NoneType' object has
+    # no attribute 'dtype'` before the explicit argument is ever considered. `device` below has
+    # the same problem with no caller-supplied alternative at all.
+    torch_dtype = kwargs.pop("torch_dtype", None)
+    device = kwargs.pop("device", None)
+    weight = getattr(comfy_linear1, "weight", None)
+    if torch_dtype is None or device is None:
+        if weight is None:
+            raise ValueError(
+                "this Linear carries no weight tensor yet, so torch_dtype and device cannot be "
+                "read from it. ComfyUI allocates weights lazily on Windows unless it is started "
+                "with --disable-dynamic-vram; pass both explicitly to patch before the state "
+                "dict is loaded."
+            )
+        torch_dtype = weight.dtype if torch_dtype is None else torch_dtype
+        device = weight.device if device is None else device
     svdq_linear = SVDQW4A4Linear(
         comfy_linear1.in_features,
         comfy_linear1.out_features + comfy_linear2.out_features,
         bias=False,
         torch_dtype=torch_dtype,
-        device=comfy_linear1.weight.device,
+        device=device,
         **kwargs,
     )
     add_comfy_cast_weights_attr(svdq_linear, comfy_linear1)


### PR DESCRIPTION
## Symptom

Loading any Z-Image SVDQuant checkpoint through the ComfyUI **server** on Windows fails:

```
AttributeError: 'NoneType' object has no attribute 'dtype'
  ComfyUI-nunchaku/models/zimage.py:133 in __init__
    self.qkv = SVDQW4A4Linear.from_linear(orig_attn.qkv, **kwargs)
```

The same node class, called directly in-process with the same flags and all custom nodes registered, loads fine — 136 SVDQ modules, no error. That asymmetry is what makes this expensive to diagnose: it looks like a bad checkpoint, a broken workflow, or a custom-node conflict, and it is none of those. A hand-written 9-node prompt reproduces it with nothing custom in the graph.

## Cause

`dict.pop(key, default)` evaluates its default **eagerly**:

```python
torch_dtype = kwargs.pop("torch_dtype", comfy_linear1.weight.dtype)
device=comfy_linear1.weight.device,
```

The weight is dereferenced on every call, including calls that pass `torch_dtype` explicitly.

ComfyUI 0.33 added a Windows-only lazy `Linear` in `comfy/ops.py`:

```python
# Issue is with `torch.empty` still reserving the full memory for the layer.
# Windows doesn't over-commit memory so without this, We are momentarily commit
# charged for the weight even though we might zero-copy it when we load the
# state dict.
torch.nn.Module.__init__(self)
self.weight = None
```

The weight appears only in `_load_from_state_dict`. `patch_model` runs before that. The lazy path is gated on `comfy.memory_management.aimdo_enabled`, which is set **only** in ComfyUI's `main.py` — hence in-process working and the server not.

## Change

Take `torch_dtype` and `device` from kwargs when given, fall back to the weight only when needed, and raise a message that names the real problem (including the user-facing workaround) when neither is available.

## Related

`nunchaku/models/linear.py:152` in the `nunchaku` package has the identical pattern in `SVDQW4A4Linear.from_linear`, which is where this particular traceback actually lands — submitted separately as nunchaku-tech/nunchaku#949. **Either fix alone leaves the other path exposed**; this one covers `fuse_linears` here.

## Workaround for users today

```
--disable-dynamic-vram
```

leaves `aimdo_enabled` False and restores the eager `Linear`. Verified with a real generation: two Z-Image SVDQuant workflows that failed without it completed and saved images with it.

## What this does not claim

- Verified on ComfyUI 0.33.0 / Python 3.13 / torch 2.13.0+cu130 / CUDA 13.2 / RTX 3090 (sm_86) / nunchaku 1.2.1, Windows 11. Not tested on Linux, where the lazy path does not engage.
- Only the Z-Image route was exercised end to end. Other loaders reach the same helpers and should behave the same, but I did not confirm them under the lazy path.
- This makes patching survive a weightless `Linear`. Whether every consumer downstream is equally tolerant is untested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
